### PR TITLE
Fix way harpoon looks for subdirectory specified in config

### DIFF
--- a/cmd/harpoon/main.go
+++ b/cmd/harpoon/main.go
@@ -76,10 +76,17 @@ func process() {
 		// ... retrieve the tree from the commit
 		tree, err := commit.Tree()
 
+		// ... get subdirectory tree
+		subDirTree, err := tree.Tree(repo.Subdirectory)
+		if err != nil {
+			fmt.Printf("Error when switching to subdirectory tree: %s\n", err)
+		}
+
 		// ... get the files iterator and print the file
-		tree.Files().ForEach(func(f *object.File) error {
-			if strings.Contains(f.Name, repo.Subdirectory) {
-				path := directory + "/" + f.Name
+		// .. make sure we're only calling the engine method on json files
+		subDirTree.Files().ForEach(func(f *object.File) error {
+			if strings.HasSuffix(f.Name, ".json") || strings.HasSuffix(f.Name, ".service") {
+				path := directory + "/" + repo.Subdirectory + "/" + f.Name
 				engine.EngineMethod(path, repo.Method)
 			}
 			return nil


### PR DESCRIPTION
It used to look for files to run the engine method on
in the repository tree with the path containing the
subdirectory string.

Now it gets the subdirectory tree and runs the engine method
on all files in the tree with a json file extenstion.

Fixes: https://github.com/redhat-et/harpoon/issues/43

Signed-off-by: Joseph Sawaya <jsawaya@redhat.com>