### PR TITLE
Fix kube example

### DIFF
--- a/examples/kube/example.yaml
+++ b/examples/kube/example.yaml
@@ -9,7 +9,7 @@ data:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: colors
+  name: colors_pod
 spec:
   containers:
   - name: colors


### PR DESCRIPTION
This changes the pod name to not coincide with the container name
in the kube example.yaml

Signed-off-by: Joseph Sawaya <jsawaya@redhat.com>