### PR TITLE
fix change to look at added file and not previous file

### DIFF
--- a/pkg/engine/harpoon.go
+++ b/pkg/engine/harpoon.go
@@ -367,8 +367,8 @@ func (hc *HarpoonConfig) getChangesAndRunEngine(ctx context.Context, gitRepo *gi
 
 	// the change logic is backwards "From" is actually "To"
 	for _, change := range changes {
-		if strings.Contains(change.To.Name, tp) {
-			path := directory + "/" + change.To.Name
+		if strings.Contains(change.From.Name, tp) {
+			path := directory + "/" + change.From.Name
 			if err := hc.EngineMethod(ctx, path, kubeMethod, target); err != nil {
 				log.Fatal(err)
 			}


### PR DESCRIPTION
This commit quickly fixes an issue where added files were not being 
recognized this is due to the way we are generating the diff in findDiff.

This is a quick solution, the problem lies in findDiff so that should be
changed to avoid confusion.

Fixes #94

Signed-off-by: Joseph Sawaya <jsawaya@redhat.com>