### PR TITLE
fix bug where engine method error is not returned

### DIFF
--- a/pkg/engine/harpoon.go
+++ b/pkg/engine/harpoon.go
@@ -333,7 +333,7 @@ func (hc *HarpoonConfig) applyInitial(ctx context.Context, fileName string, tag 
 			return nil
 		})
 		if err != nil {
-			return fileName, nil
+			return fileName, err
 		}
 	}
 	return fileName, nil


### PR DESCRIPTION
This fixes a small bug where the err for the iteration over the files in
`applyInitial()` was not being returned.

Signed-off-by: Joseph Sawaya <jsawaya@redhat.com>