### PR TITLE
Create utils directory and WrapErr function

### DIFF
--- a/pkg/engine/utils/errors.go
+++ b/pkg/engine/utils/errors.go
@@ -1,0 +1,8 @@
+package utils
+
+import "fmt"
+
+func WrapErr(e error, msg string, args ...interface{}) error {
+	final_msg := fmt.Sprintf(msg, args...)
+	return fmt.Errorf("%s: %s", final_msg, e)
+}

--- a/pkg/engine/utils/errors_test.go
+++ b/pkg/engine/utils/errors_test.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestWrapErr(t *testing.T) {
+	msg := "Error"
+	e := errors.New("other_err")
+	err := WrapErr(e, msg).Error()
+	expected := "Error: other_err"
+	if err != expected {
+		t.Fatalf("Failed: err: %s != %s", err, expected)
+	}
+
+	msg = "Error %s"
+	e = errors.New("other_err")
+	err = WrapErr(e, msg, "test").Error()
+	expected = "Error test: other_err"
+	if err != expected {
+		t.Fatalf("Failed: err: %s != %s", err, expected)
+	}
+}


### PR DESCRIPTION
This commit creates the utils directory for the engine package
for helper functions.

This commit also creates the WrapErr helper function to make
wrapping errors more comfortable. There are also very simple unit
tests to make sure the WrapErr function works properly.

Signed-off-by: Joseph Sawaya <jsawaya@redhat.com>