### PR TITLE
Better error handling

### DIFF
--- a/pkg/engine/ansible.go
+++ b/pkg/engine/ansible.go
@@ -4,9 +4,9 @@ import (
 	"context"
 
 	"github.com/containers/podman/v4/pkg/bindings/containers"
-	"github.com/containers/podman/v4/pkg/bindings/images"
 	"github.com/containers/podman/v4/pkg/specgen"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/redhat-et/harpoon/pkg/engine/utils"
 
 	"k8s.io/klog/v2"
 )
@@ -22,20 +22,8 @@ func ansiblePodman(ctx context.Context, mo *FileMountOptions) error {
 	sshImage := "quay.io/harpoon/harpoon-ansible:latest"
 
 	klog.Infof("Identifying if harpoon-ansible image exists locally")
-	// Pull image if it doesn't exist
-	var present bool
-	var err error
-	present, err = images.Exists(mo.Conn, sshImage, nil)
-	klog.Infof("Is image present? %t", present)
-	if err != nil {
+	if err := utils.FetchImage(mo.Conn, sshImage); err != nil {
 		return err
-	}
-
-	if !present {
-		_, err = images.Pull(mo.Conn, sshImage, nil)
-		if err != nil {
-			return err
-		}
 	}
 
 	s := specgen.NewSpecGenerator(sshImage, false)

--- a/pkg/engine/harpoon.go
+++ b/pkg/engine/harpoon.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/containers/podman/v4/pkg/bindings"
-	"github.com/containers/podman/v4/pkg/bindings/images"
 	"github.com/go-co-op/gocron"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
@@ -139,7 +138,7 @@ func (o *HarpoonConfig) initConfig(cmd *cobra.Command) {
 	}
 
 	klog.Infof("Identifying if harpoon image exists locally")
-	if err := fetchImage(conn, harpoonImage); err != nil {
+	if err := utils.FetchImage(conn, harpoonImage); err != nil {
 		cobra.CheckErr(err)
 	}
 	o.Conn = conn
@@ -148,43 +147,32 @@ func (o *HarpoonConfig) initConfig(cmd *cobra.Command) {
 
 // getTargets returns map of repoName to map of method:Schedule
 func (hc *HarpoonConfig) getTargets() {
-	var methods []interface{}
 	for _, target := range hc.Targets {
+		target.Mu.Lock()
+		defer target.Mu.Unlock()
 		schedMethods := make(map[string]string)
-		// TODO: this should not be hard-coded, in the future might allow for arbitrary target types with an interface
-		methods = append(methods, target.Raw, target.Systemd, target.Kube, target.FileTransfer, target.Ansible)
-		for _, i := range methods {
-			switch i.(type) {
-			case api.Raw:
-				if target.Raw.Schedule == "" {
-					continue
-				}
-				schedMethods[rawMethod] = target.Raw.Schedule
-			case api.Kube:
-				if target.Kube.Schedule == "" {
-					continue
-				}
-				schedMethods[kubeMethod] = target.Kube.Schedule
-			case api.Systemd:
-				if target.Systemd.Schedule == "" {
-					continue
-				}
-				schedMethods[systemdMethod] = target.Systemd.Schedule
-			case api.FileTransfer:
-				if target.FileTransfer.Schedule == "" {
-					continue
-				}
-				schedMethods[fileTransferMethod] = target.FileTransfer.Schedule
-			case api.Ansible:
-				if target.Ansible.Schedule == "" {
-					continue
-				}
-				schedMethods[ansibleMethod] = target.Ansible.Schedule
-			default:
-				log.Fatalf("unknown target method")
-			}
+		if target.Raw.Schedule != "" {
+			target.Raw.InitialRun = true
+			schedMethods[rawMethod] = target.Raw.Schedule
+		}
+		if target.Kube.Schedule != "" {
+			target.Kube.InitialRun = true
+			schedMethods[kubeMethod] = target.Kube.Schedule
+		}
+		if target.Systemd.Schedule != "" {
+			target.Systemd.InitialRun = true
+			schedMethods[systemdMethod] = target.Systemd.Schedule
+		}
+		if target.FileTransfer.Schedule != "" {
+			target.FileTransfer.InitialRun = true
+			schedMethods[fileTransferMethod] = target.FileTransfer.Schedule
+		}
+		if target.Ansible.Schedule != "" {
+			target.Ansible.InitialRun = true
+			schedMethods[ansibleMethod] = target.Ansible.Schedule
 		}
 		target.MethodSchedules = schedMethods
+		hc.update(target)
 	}
 }
 
@@ -194,7 +182,7 @@ func (hc *HarpoonConfig) runTargets() {
 	allTargets := make(map[string]map[string]string)
 	for _, target := range hc.Targets {
 		if err := hc.getClone(target); err != nil {
-			log.Fatal(err)
+			klog.Warningf("Repo: %s, clone error: %v, will retry next scheduled run", target.Name, err)
 		}
 		allTargets[target.Name] = target.MethodSchedules
 	}
@@ -207,15 +195,6 @@ func (hc *HarpoonConfig) runTargets() {
 				target = *t
 			}
 		}
-		directory := filepath.Base(target.Url)
-		gitRepo, err := git.PlainOpen(directory)
-		if err != nil {
-			log.Fatalf("Repo: %s, error while opening the repository: %v", directory, err)
-		}
-		_, commit, err := getTree(gitRepo, nil)
-		if err != nil {
-			log.Fatalf("Repo: %s, error getting repository tree: %v", directory, err)
-		}
 
 		for method, schedule := range schedMethods {
 			switch method {
@@ -223,54 +202,29 @@ func (hc *HarpoonConfig) runTargets() {
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 				klog.Infof("Processing Repo: %s Method: %s", target.Name, method)
-				target.Mu.Lock()
-				target.Kube.InitialRun = true
-				target.Kube.LastCommit = commit
-				hc.update(&target)
-				target.Mu.Unlock()
 				s.Cron(schedule).Do(hc.processKube, ctx, &target, schedule)
 			case rawMethod:
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 				klog.Infof("Processing Repo: %s Method: %s", target.Name, method)
-				target.Mu.Lock()
-				target.Raw.InitialRun = true
-				target.Raw.LastCommit = commit
-				hc.update(&target)
-				target.Mu.Unlock()
 				s.Cron(schedule).Do(hc.processRaw, ctx, &target, schedule)
 			case systemdMethod:
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 				klog.Infof("Processing Repo: %s Method: %s", target.Name, method)
-				target.Mu.Lock()
-				target.Systemd.InitialRun = true
-				target.Systemd.LastCommit = commit
-				hc.update(&target)
-				target.Mu.Unlock()
 				s.Cron(schedule).Do(hc.processSystemd, ctx, &target, schedule)
 			case fileTransferMethod:
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 				klog.Infof("Processing Repo: %s Method: %s", target.Name, method)
-				target.Mu.Lock()
-				target.FileTransfer.InitialRun = true
-				target.FileTransfer.LastCommit = commit
-				hc.update(&target)
-				target.Mu.Unlock()
 				s.Cron(schedule).Do(hc.processFileTransfer, ctx, &target, schedule)
 			case ansibleMethod:
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 				klog.Infof("Processing Repo: %s Method: %s", target.Name, method)
-				target.Mu.Lock()
-				target.Ansible.InitialRun = true
-				target.Ansible.LastCommit = commit
-				hc.update(&target)
-				target.Mu.Unlock()
 				s.Cron(schedule).Do(hc.processAnsible, ctx, &target, schedule)
 			default:
-				log.Fatalf("unknown target method")
+				klog.Warningf("Repo: %s Method: %s, unknown method type, ignoring", target.Name, method)
 			}
 		}
 	}
@@ -283,8 +237,6 @@ func (hc *HarpoonConfig) processRaw(ctx context.Context, target *api.Target, sch
 	defer target.Mu.Unlock()
 
 	initial := target.Raw.InitialRun
-	target.Raw.InitialRun = false
-	hc.update(target)
 	tag := []string{".json"}
 	var targetFile string
 	mo := &FileMountOptions{
@@ -294,28 +246,36 @@ func (hc *HarpoonConfig) processRaw(ctx context.Context, target *api.Target, sch
 	}
 
 	if initial {
+		retry := hc.resetTarget(target, rawMethod, true, nil)
+		if retry {
+			return
+		}
 		fileName, subDirTree, err := hc.getPathOrTree(target, target.Raw.TargetPath, rawMethod)
 		if err != nil {
-			log.Fatal(err)
+			_ = hc.resetTarget(target, rawMethod, false, err)
+			return
 		}
 		targetFile, err = hc.applyInitial(ctx, mo, fileName, target.Raw.TargetPath, &tag, subDirTree)
 		if err != nil {
-			checkInitialErr(target.Name, rawMethod, err)
+			_ = hc.resetTarget(target, rawMethod, false, err)
+			return
 		}
 		mo.Path = targetFile
 	}
 
 	if err := hc.getChangesAndRunEngine(ctx, mo); err != nil {
-		checkProcessingErr(target.Name, rawMethod, err)
+		target.Raw.InitialRun = hc.resetTarget(target, rawMethod, false, err)
+		return
 	}
+	target.Raw.InitialRun = false
+	hc.update(target)
 }
 
 func (hc *HarpoonConfig) processAnsible(ctx context.Context, target *api.Target, schedule string) {
 	target.Mu.Lock()
 	defer target.Mu.Unlock()
+
 	initial := target.Ansible.InitialRun
-	target.Ansible.InitialRun = false
-	hc.update(target)
 	tag := []string{"yaml", "yml"}
 	var targetFile = ""
 	mo := &FileMountOptions{
@@ -324,28 +284,36 @@ func (hc *HarpoonConfig) processAnsible(ctx context.Context, target *api.Target,
 		Target: target,
 	}
 	if initial {
+		retry := hc.resetTarget(target, ansibleMethod, true, nil)
+		if retry {
+			return
+		}
 		fileName, subDirTree, err := hc.getPathOrTree(target, target.Ansible.TargetPath, ansibleMethod)
 		if err != nil {
-			log.Fatal(err)
+			_ = hc.resetTarget(target, ansibleMethod, false, err)
+			return
 		}
 		targetFile, err = hc.applyInitial(ctx, mo, fileName, target.Ansible.TargetPath, &tag, subDirTree)
 		if err != nil {
-			checkInitialErr(target.Name, ansibleMethod, err)
+			_ = hc.resetTarget(target, ansibleMethod, false, err)
+			return
 		}
 		mo.Path = targetFile
 	}
 
 	if err := hc.getChangesAndRunEngine(ctx, mo); err != nil {
-		checkProcessingErr(target.Name, ansibleMethod, err)
+		target.Ansible.InitialRun = hc.resetTarget(target, ansibleMethod, false, err)
+		return
 	}
+	target.Ansible.InitialRun = false
+	hc.update(target)
 }
 
 func (hc *HarpoonConfig) processSystemd(ctx context.Context, target *api.Target, schedule string) {
 	target.Mu.Lock()
 	defer target.Mu.Unlock()
+
 	initial := target.Systemd.InitialRun
-	target.Systemd.InitialRun = false
-	hc.update(target)
 	var targetFile string
 	mo := &FileMountOptions{
 		Conn:   hc.Conn,
@@ -354,28 +322,36 @@ func (hc *HarpoonConfig) processSystemd(ctx context.Context, target *api.Target,
 	}
 	tag := []string{".service"}
 	if initial {
+		retry := hc.resetTarget(target, systemdMethod, true, nil)
+		if retry {
+			return
+		}
 		fileName, subDirTree, err := hc.getPathOrTree(target, target.Systemd.TargetPath, systemdMethod)
 		if err != nil {
-			log.Fatal(err)
+			_ = hc.resetTarget(target, systemdMethod, false, err)
+			return
 		}
 		targetFile, err = hc.applyInitial(ctx, mo, fileName, target.Systemd.TargetPath, &tag, subDirTree)
 		if err != nil {
-			checkInitialErr(target.Name, systemdMethod, err)
+			_ = hc.resetTarget(target, systemdMethod, false, err)
+			return
 		}
 		mo.Path = targetFile
 	}
 
 	if err := hc.getChangesAndRunEngine(ctx, mo); err != nil {
-		checkProcessingErr(target.Name, systemdMethod, err)
+		target.Systemd.InitialRun = hc.resetTarget(target, systemdMethod, false, err)
+		return
 	}
+	target.Systemd.InitialRun = false
+	hc.update(target)
 }
 
 func (hc *HarpoonConfig) processFileTransfer(ctx context.Context, target *api.Target, schedule string) {
 	target.Mu.Lock()
 	defer target.Mu.Unlock()
+
 	initial := target.FileTransfer.InitialRun
-	target.FileTransfer.InitialRun = false
-	hc.update(target)
 	var targetFile string
 	mo := &FileMountOptions{
 		Conn:   hc.Conn,
@@ -383,28 +359,36 @@ func (hc *HarpoonConfig) processFileTransfer(ctx context.Context, target *api.Ta
 		Target: target,
 	}
 	if initial {
+		retry := hc.resetTarget(target, fileTransferMethod, true, nil)
+		if retry {
+			return
+		}
 		fileName, subDirTree, err := hc.getPathOrTree(target, target.FileTransfer.TargetPath, fileTransferMethod)
 		if err != nil {
-			log.Fatal(err)
+			_ = hc.resetTarget(target, fileTransferMethod, false, err)
+			return
 		}
 		targetFile, err = hc.applyInitial(ctx, mo, fileName, target.FileTransfer.TargetPath, nil, subDirTree)
 		if err != nil {
-			checkInitialErr(target.Name, fileTransferMethod, err)
+			_ = hc.resetTarget(target, fileTransferMethod, false, err)
+			return
 		}
 		mo.Path = targetFile
 	}
 
 	if err := hc.getChangesAndRunEngine(ctx, mo); err != nil {
-		checkProcessingErr(target.Name, fileTransferMethod, err)
+		target.FileTransfer.InitialRun = hc.resetTarget(target, fileTransferMethod, false, err)
+		return
 	}
+	target.FileTransfer.InitialRun = false
+	hc.update(target)
 }
 
 func (hc *HarpoonConfig) processKube(ctx context.Context, target *api.Target, schedule string) {
 	target.Mu.Lock()
 	defer target.Mu.Unlock()
+
 	initial := target.Kube.InitialRun
-	target.Kube.InitialRun = false
-	hc.update(target)
 	tag := []string{"yaml", "yml"}
 	var targetFile string
 	mo := &FileMountOptions{
@@ -413,48 +397,57 @@ func (hc *HarpoonConfig) processKube(ctx context.Context, target *api.Target, sc
 		Target: target,
 	}
 	if initial {
+		retry := hc.resetTarget(target, kubeMethod, true, nil)
+		if retry {
+			return
+		}
 		fileName, subDirTree, err := hc.getPathOrTree(target, target.Kube.TargetPath, kubeMethod)
 		if err != nil {
-			log.Fatal(err)
+			_ = hc.resetTarget(target, kubeMethod, false, err)
+			return
 		}
 		targetFile, err = hc.applyInitial(ctx, mo, fileName, target.Kube.TargetPath, &tag, subDirTree)
 		if err != nil {
-			checkInitialErr(target.Name, kubeMethod, err)
+			_ = hc.resetTarget(target, kubeMethod, false, err)
+			return
 		}
 		mo.Path = targetFile
 	}
 
 	if err := hc.getChangesAndRunEngine(ctx, mo); err != nil {
-		checkProcessingErr(target.Name, kubeMethod, err)
+		target.Kube.InitialRun = hc.resetTarget(target, kubeMethod, false, err)
+		return
 	}
+	target.Kube.InitialRun = false
+	hc.update(target)
 }
 
 func (hc *HarpoonConfig) applyInitial(ctx context.Context, mo *FileMountOptions, fileName, tp string, tag *[]string, subDirTree *object.Tree) (string, error) {
 	directory := filepath.Base(mo.Target.Url)
 	if fileName != "" {
 		found := false
-		if hc.checkTag(tag, fileName) {
+		if checkTag(tag, fileName) {
 			found = true
 			mo.Path = filepath.Join(directory, fileName)
 			if err := hc.EngineMethod(ctx, mo, nil); err != nil {
-				return fileName, utils.WrapErr(err, "error running engine with method %s, for file %s, for commit %s",
-					mo.Method, fileName, mo.Target.Kube.LastCommit.Hash.String())
+				return fileName, utils.WrapErr(err, "error running engine with method %s, for file %s",
+					mo.Method, fileName)
 			}
 		}
 		if !found {
 			err := fmt.Errorf("%s target file must be of type %v", mo.Method, tag)
-			return fileName, utils.WrapErr(err, "error running engine with method %s, for file %s, for commit %s",
-				mo.Method, fileName, mo.Target.Kube.LastCommit.Hash.String())
+			return fileName, utils.WrapErr(err, "error running engine with method %s, for file %s",
+				mo.Method, fileName)
 		}
 
 	} else {
 		// ... get the files iterator and print the file
 		err := subDirTree.Files().ForEach(func(f *object.File) error {
-			if hc.checkTag(tag, f.Name) {
+			if checkTag(tag, f.Name) {
 				mo.Path = filepath.Join(directory, tp, f.Name)
 				if err := hc.EngineMethod(ctx, mo, nil); err != nil {
-					return utils.WrapErr(err, "error running engine with method %s, for file %s for commit %s",
-						mo.Method, mo.Path, mo.Target.Kube.LastCommit.Hash.String())
+					return utils.WrapErr(err, "error running engine with method %s, for file %s",
+						mo.Method, mo.Path)
 				}
 			}
 			return nil
@@ -464,37 +457,6 @@ func (hc *HarpoonConfig) applyInitial(ctx context.Context, mo *FileMountOptions,
 		}
 	}
 	return fileName, nil
-}
-
-func (hc *HarpoonConfig) checkTag(tags *[]string, name string) bool {
-	if tags == nil {
-		return true
-	}
-	for _, tag := range *tags {
-		if strings.HasSuffix(name, tag) {
-			return true
-		}
-	}
-	return false
-}
-
-func (hc *HarpoonConfig) setLastCommit(target *api.Target, method string, commit *object.Commit) error {
-	switch method {
-	case ansibleMethod:
-		target.Ansible.LastCommit = commit
-	case rawMethod:
-		target.Raw.LastCommit = commit
-	case systemdMethod:
-		target.Systemd.LastCommit = commit
-	case kubeMethod:
-		target.Kube.LastCommit = commit
-	case fileTransferMethod:
-		target.FileTransfer.LastCommit = commit
-	default:
-		return fmt.Errorf("unknown method: %s", method)
-	}
-	hc.update(target)
-	return nil
 }
 
 func (hc *HarpoonConfig) getChangesAndRunEngine(ctx context.Context, mo *FileMountOptions) error {
@@ -525,9 +487,12 @@ func (hc *HarpoonConfig) getChangesAndRunEngine(ctx context.Context, mo *FileMou
 	}
 	changesThisMethod, newCommit, err := hc.findDiff(mo.Target, mo.Method, tp, lastCommit)
 	if err != nil {
-		return utils.WrapErr(err, "error getting diff for method %s, last commit %s", mo.Method, lastCommit.String())
+		return utils.WrapErr(err, "error method: %s commit: %s", mo.Method, lastCommit.Hash.String())
 	}
+
 	hc.setLastCommit(mo.Target, mo.Method, newCommit)
+	hc.update(mo.Target)
+
 	if len(changesThisMethod) == 0 {
 		klog.Infof("Repo: %s, Method: %s: Nothing to pull.....Requeuing", mo.Target.Name, mo.Method)
 		return nil
@@ -536,8 +501,7 @@ func (hc *HarpoonConfig) getChangesAndRunEngine(ctx context.Context, mo *FileMou
 	for change, path := range changesThisMethod {
 		mo.Path = path
 		if err := hc.EngineMethod(ctx, mo, change); err != nil {
-			return utils.WrapErr(err, "error running engine with method %s, for file %s, for commit %s", mo.Method, mo.Path, newCommit)
-
+			return utils.WrapErr(err, "error method: %s path: %s, commit: %s", mo.Method, mo.Path, newCommit.Hash.String())
 		}
 	}
 	return nil
@@ -561,7 +525,7 @@ func (hc *HarpoonConfig) findDiff(target *api.Target, method, targetPath string,
 	}
 	w, err := gitRepo.Worktree()
 	if err != nil {
-		return thisMethodChanges, nil, fmt.Errorf("error while opening the worktree: %s", err)
+		return thisMethodChanges, nil, fmt.Errorf("error while opening the worktree: %v", err)
 	}
 	// ... retrieve the tree from this method's last fetched commit
 	beforeFetchTree, _, err := getTree(gitRepo, commit)
@@ -606,15 +570,18 @@ func (hc *HarpoonConfig) findDiff(target *api.Target, method, targetPath string,
 		} else if strings.Contains(change.To.Name, targetPath) {
 			thisMethodChanges[change] = deleteFile
 		}
-
 	}
+
 	return thisMethodChanges, newestCommit, nil
 }
 
 func (hc *HarpoonConfig) EngineMethod(ctx context.Context, mo *FileMountOptions, change *object.Change) error {
 	switch mo.Method {
 	case rawMethod:
-		var prev *string = getChangeString(change)
+		prev, err := getChangeString(change)
+		if err != nil {
+			return err
+		}
 		mo.Previous = prev
 		return rawPodman(ctx, mo)
 	case systemdMethod:
@@ -643,7 +610,10 @@ func (hc *HarpoonConfig) EngineMethod(ctx context.Context, mo *FileMountOptions,
 		mo.Dest = mo.Target.FileTransfer.DestinationDirectory
 		return fileTransferPodman(ctx, mo)
 	case kubeMethod:
-		var prev *string = getChangeString(change)
+		prev, err := getChangeString(change)
+		if err != nil {
+			return err
+		}
 		mo.Previous = prev
 		return kubePodman(ctx, mo)
 	case ansibleMethod:
@@ -653,31 +623,11 @@ func (hc *HarpoonConfig) EngineMethod(ctx context.Context, mo *FileMountOptions,
 	}
 }
 
-func getChangeString(change *object.Change) *string {
-	if change != nil {
-		_, to, err := change.Files()
-		if err != nil {
-			log.Fatal(err)
-		}
-		if to != nil {
-			s, err := to.Contents()
-			if err != nil {
-				log.Fatal(err)
-			}
-			return &s
-		}
-	}
-	return nil
-}
-
-// This assumes unique urls - only 1 git repo per "directory"
 func (hc *HarpoonConfig) getClone(target *api.Target) error {
-	target.Mu.Lock()
-	defer target.Mu.Unlock()
 	directory := filepath.Base(target.Url)
 	absPath, err := filepath.Abs(directory)
 	if err != nil {
-		return fmt.Errorf("Repo: %s, error while fetching local clone: %s", target.Name, err)
+		return err
 	}
 	var exists bool
 	if _, err := os.Stat(directory); err == nil {
@@ -687,7 +637,7 @@ func (hc *HarpoonConfig) getClone(target *api.Target) error {
 			return fmt.Errorf("%s exists but is not a git repository", directory)
 		}
 	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("error retrieving git repository: %s: %v", directory, err)
+		return err
 	}
 
 	if !exists {
@@ -706,10 +656,150 @@ func (hc *HarpoonConfig) getClone(target *api.Target) error {
 			SingleBranch:  true,
 		})
 		if err != nil {
-			return fmt.Errorf("Error while cloning the repository: %s", err)
+			return err
 		}
 	}
 	return nil
+}
+
+func (hc *HarpoonConfig) getPathOrTree(target *api.Target, subDir, method string) (string, *object.Tree, error) {
+	directory := filepath.Base(target.Url)
+	gitRepo, err := git.PlainOpen(directory)
+	if err != nil {
+		return "", nil, err
+	}
+	tree, _, err := getTree(gitRepo, nil)
+	if err != nil {
+		return "", nil, err
+	}
+
+	subDirTree, err := tree.Tree(subDir)
+	if err != nil {
+		if err == object.ErrDirectoryNotFound {
+			// check if exact filepath
+			file, err := tree.File(subDir)
+			if err == nil {
+				return file.Name, nil, nil
+			}
+		}
+	}
+	return "", subDirTree, err
+}
+
+// arrive at resetTarget 1 of 2 ways:
+//      1) initial run of target - will return true if clone or commit fetch fails, to try again next run
+//      2) processing error during run - will attempt to fetch the remote commit and reset to InitialRun true for the
+//         next run, or, if fetching of commit fails, will return true to try again next run
+// resetTarget returns true if the target should be re-cloned next run, and it will set
+func (hc *HarpoonConfig) resetTarget(target *api.Target, method string, initial bool, err error) bool {
+	if err != nil {
+		klog.Warningf("Repo: %s Method: %s encountered error: %v, resetting...", target.Name, method, err)
+	}
+	commit, err := hc.getGit(target, initial)
+	if err != nil {
+		klog.Warningf("Repo: %s error getting next commit, will try again next scheduled run: %v", target.Name, err)
+		return true
+	}
+	if commit == nil {
+		klog.Warningf("Repo: %s, fetched empty commit, will retry next scheduled run", target.Name)
+		return true
+	}
+
+	return hc.setInitial(target, commit, method)
+}
+
+func (hc *HarpoonConfig) getGit(target *api.Target, initialRun bool) (*object.Commit, error) {
+	if initialRun {
+		if err := hc.getClone(target); err != nil {
+			return nil, err
+		}
+	}
+	directory := filepath.Base(target.Url)
+	gitRepo, err := git.PlainOpen(directory)
+	if err != nil {
+		return nil, err
+	}
+
+	_, commit, err := getTree(gitRepo, nil)
+	if err != nil {
+		return nil, err
+	}
+	return commit, nil
+}
+
+// setInitial will return true if fetching of commit fails or results in empty commit, to try again next run
+// or, if valid commit is fetched, will set InitialRun true and LastCommit for the method, to process next run
+func (hc *HarpoonConfig) setInitial(target *api.Target, commit *object.Commit, method string) bool {
+	retry := false
+	hc.setInitialRun(target, method)
+	if commit == nil {
+		retry = true
+	} else {
+		hc.setLastCommit(target, method, commit)
+	}
+	hc.update(target)
+	return retry
+}
+
+func (hc *HarpoonConfig) setLastCommit(target *api.Target, method string, commit *object.Commit) {
+	switch method {
+	case kubeMethod:
+		target.Kube.LastCommit = commit
+	case rawMethod:
+		target.Raw.LastCommit = commit
+	case systemdMethod:
+		target.Systemd.LastCommit = commit
+	case fileTransferMethod:
+		target.FileTransfer.LastCommit = commit
+	case ansibleMethod:
+		target.Ansible.LastCommit = commit
+	}
+}
+
+// setInitialRun is called before the initial processing of a target, or
+// upon any processing errors for the method, so the method will be retried with next run
+func (hc *HarpoonConfig) setInitialRun(target *api.Target, method string) {
+	switch method {
+	case kubeMethod:
+		target.Kube.InitialRun = true
+	case rawMethod:
+		target.Raw.InitialRun = true
+	case systemdMethod:
+		target.Systemd.InitialRun = true
+	case fileTransferMethod:
+		target.FileTransfer.InitialRun = true
+	case ansibleMethod:
+		target.Ansible.InitialRun = true
+	}
+}
+
+func getChangeString(change *object.Change) (*string, error) {
+	if change != nil {
+		_, to, err := change.Files()
+		if err != nil {
+			return nil, err
+		}
+		if to != nil {
+			s, err := to.Contents()
+			if err != nil {
+				return nil, err
+			}
+			return &s, nil
+		}
+	}
+	return nil, nil
+}
+
+func checkTag(tags *[]string, name string) bool {
+	if tags == nil {
+		return true
+	}
+	for _, tag := range *tags {
+		if strings.HasSuffix(name, tag) {
+			return true
+		}
+	}
+	return false
 }
 
 func getTree(r *git.Repository, oldCommit *object.Commit) (*object.Tree, *object.Commit, error) {
@@ -738,53 +828,4 @@ func getTree(r *git.Repository, oldCommit *object.Commit) (*object.Tree, *object
 		return nil, nil, fmt.Errorf("error when retrieving tree: %s", err)
 	}
 	return tree, newCommit, nil
-}
-
-func (hc *HarpoonConfig) getPathOrTree(target *api.Target, subDir, method string) (string, *object.Tree, error) {
-	directory := filepath.Base(target.Url)
-	gitRepo, err := git.PlainOpen(directory)
-	if err != nil {
-		log.Fatalf("Repo: %s, error while opening the repository: %s", directory, err)
-	}
-	tree, _, err := getTree(gitRepo, nil)
-	if err != nil {
-		return "", nil, err
-	}
-
-	subDirTree, err := tree.Tree(subDir)
-	if err != nil {
-		if err == object.ErrDirectoryNotFound {
-			// check if exact filepath
-			file, err := tree.File(subDir)
-			if err == nil {
-				return file.Name, nil, nil
-			}
-		}
-	}
-	return "", subDirTree, err
-}
-
-func checkInitialErr(name, method string, err error) {
-	klog.Errorf("Repo: %s Method: %s, error with initial processing of repository: %v", name, method, err)
-}
-
-func checkProcessingErr(name, method string, err error) {
-	klog.Errorf("Repo: %s Method: %s, error processing repository: %v", name, method, err)
-}
-
-func fetchImage(conn context.Context, image string) error {
-	present, err := images.Exists(conn, image, nil)
-	klog.Infof("Is image present? %t", present)
-	if err != nil {
-		return err
-	}
-
-	if !present {
-		_, err = images.Pull(conn, image, nil)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }

--- a/pkg/engine/harpoon.go
+++ b/pkg/engine/harpoon.go
@@ -525,7 +525,7 @@ func (hc *HarpoonConfig) getChangesAndRunEngine(ctx context.Context, mo *FileMou
 	}
 	changesThisMethod, newCommit, err := hc.findDiff(mo.Target, mo.Method, tp, lastCommit)
 	if err != nil {
-		return utils.WrapErr(err, "error getting diff for method %s, last commit %s: %s", mo.Method, lastCommit.String())
+		return utils.WrapErr(err, "error getting diff for method %s, last commit %s", mo.Method, lastCommit.String())
 	}
 	hc.setLastCommit(mo.Target, mo.Method, newCommit)
 	if len(changesThisMethod) == 0 {
@@ -536,7 +536,7 @@ func (hc *HarpoonConfig) getChangesAndRunEngine(ctx context.Context, mo *FileMou
 	for change, path := range changesThisMethod {
 		mo.Path = path
 		if err := hc.EngineMethod(ctx, mo, change); err != nil {
-			return utils.WrapErr(err, "error running engine with method %s, for file %s, for commit %s: %s", mo.Method, mo.Path, newCommit)
+			return utils.WrapErr(err, "error running engine with method %s, for file %s, for commit %s", mo.Method, mo.Path, newCommit)
 
 		}
 	}
@@ -586,7 +586,7 @@ func (hc *HarpoonConfig) findDiff(target *api.Target, method, targetPath string,
 		Branch: refName,
 		Force:  true,
 	}); err != nil {
-		return thisMethodChanges, nil, fmt.Errorf("error checking out latest branch %s: %v", directory, ref, err)
+		return thisMethodChanges, nil, fmt.Errorf("error checking out latest branch %s: %v", ref, err)
 	}
 
 	afterFetchTree, newestCommit, err := getTree(gitRepo, nil)

--- a/pkg/engine/kube.go
+++ b/pkg/engine/kube.go
@@ -21,12 +21,13 @@ import (
 )
 
 func kubePodman(ctx context.Context, mo *FileMountOptions) error {
+
 	if mo.Path != deleteFile {
 		klog.Infof("Creating podman container from %s using kube method", mo.Path)
 	}
 
 	if mo.Previous != nil {
-		err := stopPods(ctx, []byte(*mo.Previous))
+		err := stopPods(mo.Conn, []byte(*mo.Previous))
 		if err != nil {
 			return utils.WrapErr(err, "Error stopping pods")
 		}
@@ -38,7 +39,7 @@ func kubePodman(ctx context.Context, mo *FileMountOptions) error {
 			return utils.WrapErr(err, "Error reading file")
 		}
 
-		err = stopPods(ctx, kubeYaml)
+		err = stopPods(mo.Conn, kubeYaml)
 		if err != nil {
 			return utils.WrapErr(err, "Error stopping pods")
 		}

--- a/pkg/engine/kube.go
+++ b/pkg/engine/kube.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/containers/podman/v4/pkg/bindings/play"
 	"github.com/containers/podman/v4/pkg/bindings/pods"
+	"github.com/redhat-et/harpoon/pkg/engine/utils"
 
 	"gopkg.in/yaml.v3"
 	v1 "k8s.io/api/core/v1"
@@ -26,33 +27,34 @@ func kubePodman(ctx context.Context, mo *FileMountOptions) error {
 	if mo.Previous != nil {
 		err := stopPods(mo.Conn, []byte(*mo.Previous))
 		if err != nil {
-			return err
+			return utils.WrapErr(err, "Error stopping pod")
 		}
 	}
 
 	if mo.Path != deleteFile {
 		kubeYaml, err := ioutil.ReadFile(mo.Path)
 		if err != nil {
-			return err
+			return utils.WrapErr(err, "Error reading file")
 		}
 		err = stopPods(mo.Conn, kubeYaml)
 		if err != nil {
-			return err
+			return utils.WrapErr(err, "Error stopping pod")
 		}
 
 		err = createPods(mo.Conn, mo.Path, kubeYaml)
 		if err != nil {
-			return err
+			return utils.WrapErr(err, "Error creating pod")
 		}
 	}
 
 	return nil
 }
 
+// This should be deprecated in favour of play.KubeDown() at some point
 func stopPods(ctx context.Context, specs []byte) error {
 	pod_list, err := podsToStop([]byte(specs))
 	if err != nil {
-		return err
+		return utils.WrapErr(err, "Error getting list of pods to stop")
 	}
 
 	var pod_map = make(map[string]bool)
@@ -63,14 +65,14 @@ func stopPods(ctx context.Context, specs []byte) error {
 
 	report, err := pods.List(ctx, nil)
 	if err != nil {
-		return err
+		return utils.WrapErr(err, "Error getting list of pods from podman")
 	}
 	for _, p := range report {
 		if _, ok := pod_map[p.Name]; ok {
 			klog.Infof("Tearing down pod: %s\n", p.Name)
 			err = tearDownPods(ctx, p.Name)
 			if err != nil {
-				return err
+				return utils.WrapErr(err, "error tearing down pod %s", p.Name)
 			}
 		}
 	}
@@ -81,11 +83,11 @@ func stopPods(ctx context.Context, specs []byte) error {
 func tearDownPods(ctx context.Context, podName string) error {
 	_, err := pods.Stop(ctx, podName, nil)
 	if err != nil {
-		return err
+		return utils.WrapErr(err, "error stopping pod %s", podName)
 	}
 	_, err = pods.Remove(ctx, podName, nil)
 	if err != nil {
-		return err
+		return utils.WrapErr(err, "error removing pod %s", podName)
 	}
 
 	return nil
@@ -94,19 +96,19 @@ func tearDownPods(ctx context.Context, podName string) error {
 func createPods(ctx context.Context, path string, specs []byte) error {
 	pod_list, err := podFromBytes(specs)
 	if err != nil {
-		return err
+		return utils.WrapErr(err, "error getting list of pods in spec")
 	}
 
 	for _, pod := range pod_list {
 		err = validatePod(pod)
 		if err != nil {
-			return err
+			return utils.WrapErr(err, "error validating pod spec")
 		}
 	}
 
 	_, err = play.Kube(ctx, path, nil)
 	if err != nil {
-		return err
+		return utils.WrapErr(err, "error playing kube spec")
 	}
 
 	klog.Infof("Created pods from spec in %s\n", path)
@@ -115,44 +117,46 @@ func createPods(ctx context.Context, path string, specs []byte) error {
 
 func podsToStop(curr []byte) ([]string, error) {
 	pod_list, err := podFromBytes(curr)
-	ret := make([]string, 0)
 	if err != nil {
-		return nil, err
+		return nil, utils.WrapErr(err, "error getting list of pods in spec")
 	}
+
+	ret := make([]string, 0)
 	for _, pod := range pod_list {
 		ret = append(ret, pod.ObjectMeta.Name)
 	}
+
 	return ret, nil
 }
 
 func podFromBytes(input []byte) ([]v1.Pod, error) {
-	ret := make([]v1.Pod, 0)
 	var i interface{}
 	var t metav1.TypeMeta
 	pod := v1.Pod{}
 	d := yaml.NewDecoder(bytes.NewReader(input))
+	ret := make([]v1.Pod, 0)
 	for {
 		err := d.Decode(&i)
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
-			return ret, err
+			return ret, utils.WrapErr(err, "error decoding yaml")
 		}
 
 		o, err := yaml.Marshal(i)
 		if err != nil {
-			return ret, err
+			return ret, utils.WrapErr(err, "error marshalling yaml into object for conversion to json")
 		}
 
 		b, err := k8syaml.YAMLToJSON(o)
 		if err != nil {
-			return ret, err
+			return ret, utils.WrapErr(err, "error converting yaml to json")
 		}
 
 		err = json.Unmarshal(b, &t)
 		if err != nil {
-			return ret, err
+			return ret, utils.WrapErr(err, "error unmarshalling json object")
 		}
 
 		if t.Kind != "Pod" {
@@ -161,7 +165,7 @@ func podFromBytes(input []byte) ([]v1.Pod, error) {
 
 		err = json.Unmarshal(b, &pod)
 		if err != nil {
-			return ret, err
+			return ret, utils.WrapErr(err, "error unmarshalling json into pod object")
 		}
 
 		ret = append(ret, pod)

--- a/pkg/engine/kube.go
+++ b/pkg/engine/kube.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/containers/podman/v4/pkg/bindings/play"
 	"github.com/containers/podman/v4/pkg/bindings/pods"
+	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/redhat-et/harpoon/pkg/engine/utils"
 
 	"gopkg.in/yaml.v3"
@@ -25,9 +26,9 @@ func kubePodman(ctx context.Context, mo *FileMountOptions) error {
 	}
 
 	if mo.Previous != nil {
-		err := stopPods(mo.Conn, []byte(*mo.Previous))
+		err := stopPods(ctx, []byte(*mo.Previous))
 		if err != nil {
-			return utils.WrapErr(err, "Error stopping pod")
+			return utils.WrapErr(err, "Error stopping pods")
 		}
 	}
 
@@ -36,9 +37,10 @@ func kubePodman(ctx context.Context, mo *FileMountOptions) error {
 		if err != nil {
 			return utils.WrapErr(err, "Error reading file")
 		}
-		err = stopPods(mo.Conn, kubeYaml)
+
+		err = stopPods(ctx, kubeYaml)
 		if err != nil {
-			return utils.WrapErr(err, "Error stopping pod")
+			return utils.WrapErr(err, "Error stopping pods")
 		}
 
 		err = createPods(mo.Conn, mo.Path, kubeYaml)
@@ -50,122 +52,151 @@ func kubePodman(ctx context.Context, mo *FileMountOptions) error {
 	return nil
 }
 
-// This should be deprecated in favour of play.KubeDown() at some point
-func stopPods(ctx context.Context, specs []byte) error {
-	pod_list, err := podsToStop([]byte(specs))
+func stopPods(conn context.Context, input []byte) error {
+	podList, err := podFromBytes(input)
 	if err != nil {
-		return utils.WrapErr(err, "Error getting list of pods to stop")
+		return utils.WrapErr(err, "Error getting list of pods in spec")
 	}
 
-	var pod_map = make(map[string]bool)
-
-	for _, pod := range pod_list {
-		pod_map[pod] = true
+	podNameList, err := getPodNames(podList)
+	if err != nil {
+		return utils.WrapErr(err, "Error getting list of pod names")
 	}
 
-	report, err := pods.List(ctx, nil)
+	podMap := podMapFromList(podNameList)
+
+	report, err := pods.List(conn, nil)
 	if err != nil {
 		return utils.WrapErr(err, "Error getting list of pods from podman")
 	}
-	for _, p := range report {
-		if _, ok := pod_map[p.Name]; ok {
-			klog.Infof("Tearing down pod: %s\n", p.Name)
-			err = tearDownPods(ctx, p.Name)
-			if err != nil {
-				return utils.WrapErr(err, "error tearing down pod %s", p.Name)
-			}
-		}
+
+	runningPodNameList := reportToPodNameList(report)
+
+	podsToBeDeleted := filterPods(runningPodNameList, podMap)
+
+	err = tearDownPods(conn, podsToBeDeleted)
+	if err != nil {
+		return utils.WrapErr(err, "Error tearing down pods")
 	}
 
 	return nil
 }
 
-func tearDownPods(ctx context.Context, podName string) error {
-	_, err := pods.Stop(ctx, podName, nil)
-	if err != nil {
-		return utils.WrapErr(err, "error stopping pod %s", podName)
+func podMapFromList(podNameList []string) map[string]bool {
+	podMap := make(map[string]bool)
+	for _, pod := range podNameList {
+		podMap[pod] = true
 	}
-	_, err = pods.Remove(ctx, podName, nil)
-	if err != nil {
-		return utils.WrapErr(err, "error removing pod %s", podName)
+	return podMap
+}
+
+func reportToPodNameList(report []*entities.ListPodsReport) []string {
+	ret := make([]string, 0)
+	for _, r := range report {
+		ret = append(ret, r.Name)
+	}
+	return ret
+}
+
+func filterPods(runningPodNameList []string, podMap map[string]bool) []string {
+	ret := make([]string, 0)
+	for _, p := range runningPodNameList {
+		if _, ok := podMap[p]; ok {
+			ret = append(ret, p)
+		}
 	}
 
+	return ret
+}
+
+func tearDownPods(ctx context.Context, podNameList []string) error {
+	for _, podName := range podNameList {
+		_, err := pods.Stop(ctx, podName, nil)
+		if err != nil {
+			return utils.WrapErr(err, "Error stopping pod %s", podName)
+		}
+		_, err = pods.Remove(ctx, podName, nil)
+		if err != nil {
+			return utils.WrapErr(err, "Error removing pod %s", podName)
+		}
+	}
 	return nil
 }
 
 func createPods(ctx context.Context, path string, specs []byte) error {
 	pod_list, err := podFromBytes(specs)
 	if err != nil {
-		return utils.WrapErr(err, "error getting list of pods in spec")
+		return utils.WrapErr(err, "Error getting list of pods in spec")
 	}
 
 	for _, pod := range pod_list {
 		err = validatePod(pod)
 		if err != nil {
-			return utils.WrapErr(err, "error validating pod spec")
+			return utils.WrapErr(err, "Error validating pod spec")
 		}
 	}
 
 	_, err = play.Kube(ctx, path, nil)
 	if err != nil {
-		return utils.WrapErr(err, "error playing kube spec")
+		return utils.WrapErr(err, "Error playing kube spec")
 	}
 
 	klog.Infof("Created pods from spec in %s\n", path)
 	return nil
 }
 
-func podsToStop(curr []byte) ([]string, error) {
-	pod_list, err := podFromBytes(curr)
-	if err != nil {
-		return nil, utils.WrapErr(err, "error getting list of pods in spec")
-	}
-
+func getPodNames(podList []v1.Pod) ([]string, error) {
 	ret := make([]string, 0)
-	for _, pod := range pod_list {
-		ret = append(ret, pod.ObjectMeta.Name)
+
+	for _, pod := range podList {
+		if pod.ObjectMeta.Name != "" {
+			ret = append(ret, pod.ObjectMeta.Name)
+		} else {
+			return nil, errors.New("pod has no name")
+		}
 	}
 
 	return ret, nil
 }
 
 func podFromBytes(input []byte) ([]v1.Pod, error) {
-	var i interface{}
 	var t metav1.TypeMeta
-	pod := v1.Pod{}
 	d := yaml.NewDecoder(bytes.NewReader(input))
 	ret := make([]v1.Pod, 0)
+
 	for {
+		var i interface{}
 		err := d.Decode(&i)
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
-			return ret, utils.WrapErr(err, "error decoding yaml")
+			return ret, utils.WrapErr(err, "Error decoding yaml")
 		}
 
 		o, err := yaml.Marshal(i)
 		if err != nil {
-			return ret, utils.WrapErr(err, "error marshalling yaml into object for conversion to json")
+			return ret, utils.WrapErr(err, "Error marshalling yaml into object for conversion to json")
 		}
 
 		b, err := k8syaml.YAMLToJSON(o)
 		if err != nil {
-			return ret, utils.WrapErr(err, "error converting yaml to json")
+			return ret, utils.WrapErr(err, "Error converting yaml to json")
 		}
 
 		err = json.Unmarshal(b, &t)
 		if err != nil {
-			return ret, utils.WrapErr(err, "error unmarshalling json object")
+			return ret, utils.WrapErr(err, "Error unmarshalling json object")
 		}
 
 		if t.Kind != "Pod" {
 			continue
 		}
 
+		pod := v1.Pod{}
 		err = json.Unmarshal(b, &pod)
 		if err != nil {
-			return ret, utils.WrapErr(err, "error unmarshalling json into pod object")
+			return ret, utils.WrapErr(err, "Error unmarshalling json into pod object")
 		}
 
 		ret = append(ret, pod)

--- a/pkg/engine/kube_test.go
+++ b/pkg/engine/kube_test.go
@@ -1,0 +1,236 @@
+package engine
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/containers/podman/v4/pkg/domain/entities"
+	"gopkg.in/yaml.v3"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestValidatePod(t *testing.T) {
+	var pod v1.Pod = v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "test1",
+				},
+				{
+					Name: "test2",
+				},
+			},
+		},
+	}
+
+	err := validatePod(pod)
+	if err != nil {
+		t.Errorf("expected no error, got %s", err)
+	}
+
+	pod.Spec.Containers[0].Name = pod.ObjectMeta.Name
+
+	err = validatePod(pod)
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
+
+}
+
+var invalidYaml = `
+apiVersion: v1
+		kind: Pod
+	metadata`
+
+var notPodYaml = `
+apiVersion: v1
+kind: ConfigMap`
+
+var podYaml = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test_pod1
+spec:
+  containers:
+  - name: test1
+    image: test1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test_pod2
+spec:
+  containers:
+  - name: test2
+    image: test2`
+
+var expectedPodList = []v1.Pod{
+	{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test_pod1",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "test1",
+					Image: "test1",
+				},
+			},
+		},
+	}, {
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test_pod2",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "test2",
+					Image: "test2",
+				},
+			},
+		},
+	},
+}
+
+func comparePodList(t *testing.T, expected []v1.Pod, actual []v1.Pod) {
+	m := make(map[string]int)
+
+	if len(expected) != len(actual) {
+		t.Errorf("expected %d pods, got %d", len(expected), len(actual))
+	}
+
+	for _, pod := range expected {
+		pod_bytes, err := yaml.Marshal(pod)
+		if err != nil {
+			t.Errorf("error running test: %s", err)
+		}
+		if _, ok := m[string(pod_bytes)]; ok {
+			m[string(pod_bytes)] += 1
+		} else {
+			m[string(pod_bytes)] = 1
+		}
+	}
+
+	for _, pod := range actual {
+		pod_bytes, err := yaml.Marshal(pod)
+		if err != nil {
+			t.Errorf("error running test: %s", err)
+		}
+		if _, ok := m[string(pod_bytes)]; !ok {
+			t.Errorf("actual pod not in expected pods: %s", string(pod_bytes))
+		}
+		m[string(pod_bytes)] -= 1
+		if m[string(pod_bytes)] == 0 {
+			delete(m, string(pod_bytes))
+		}
+	}
+
+	if len(m) != 0 {
+		t.Errorf("missing actual pods from expected pods")
+	}
+}
+
+func TestPodFromBytes(t *testing.T) {
+	_, err := podFromBytes([]byte(invalidYaml))
+	if err == nil {
+		t.Error("expected error, got nothing")
+	} else if !strings.Contains(err.Error(), "Error decoding yaml") {
+		t.Errorf("expected error, got %s", err)
+	}
+
+	_, err = podFromBytes([]byte(notPodYaml))
+	if err != nil {
+		t.Errorf("expected no error, got %s", err)
+	}
+
+	actualPodList, err := podFromBytes([]byte(podYaml))
+	if err != nil {
+		t.Errorf("expected no error, got %s", err)
+	}
+
+	comparePodList(t, expectedPodList, actualPodList)
+}
+
+var podListMissingName = []v1.Pod{
+	{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+	},
+}
+
+func TestGetPodNames(t *testing.T) {
+	_, err := getPodNames(podListMissingName)
+	if !strings.Contains(err.Error(), "pod has no name") {
+		t.Errorf("expected no error: %s", err)
+	}
+	res, err := getPodNames(expectedPodList)
+	if err != nil {
+		t.Errorf("expected no error: %s", err)
+	}
+	if !reflect.DeepEqual(res, []string{"test_pod1", "test_pod2"}) {
+		t.Errorf("expected pods to stop: %v, got %v", []string{"test_pod1"}, res)
+	}
+}
+
+func TestPodMapFromList(t *testing.T) {
+	expected := map[string]bool{
+		"test1": true,
+		"test2": true,
+	}
+	s := []string{"test1", "test2"}
+	actual := podMapFromList(s)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func TestReportToPodNameList(t *testing.T) {
+	lpr := entities.ListPodsReport{
+		Name: "test",
+	}
+
+	report := []*entities.ListPodsReport{
+		&lpr,
+		&lpr,
+	}
+	expected := []string{"test", "test"}
+	actual := reportToPodNameList(report)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func TestFilterPods(t *testing.T) {
+	expected := []string{"test1", "test2"}
+	l := []string{"test1", "test2", "test3"}
+	m := map[string]bool{
+		"test1": true,
+		"test2": true,
+		"test4": true,
+	}
+	actual := filterPods(l, m)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+
+}

--- a/pkg/engine/systemd.go
+++ b/pkg/engine/systemd.go
@@ -28,7 +28,7 @@ func systemdPodman(ctx context.Context, mo *FileMountOptions) error {
 
 func enableSystemdService(conn context.Context, root bool, systemdPath, service, repoName string) error {
 	klog.Infof("Identifying if systemd image exists locally")
-	if err := fetchImage(conn, systemdImage); err != nil {
+	if err := utils.FetchImage(conn, systemdImage); err != nil {
 		return err
 	}
 	os.Setenv("ROOT", "true")

--- a/pkg/engine/systemd.go
+++ b/pkg/engine/systemd.go
@@ -2,20 +2,21 @@ package engine
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 
 	"github.com/containers/podman/v4/pkg/specgen"
 	"github.com/opencontainers/runtime-spec/specs-go"
+
+	"github.com/redhat-et/harpoon/pkg/engine/utils"
 	"k8s.io/klog/v2"
 )
 
 func systemdPodman(ctx context.Context, mo *FileMountOptions) error {
 	klog.Infof("Deploying systemd file(s) %s", mo.Path)
 	if err := fileTransferPodman(ctx, mo); err != nil {
-		return fmt.Errorf("Repo: %s, Method: %s, %v", err)
+		return utils.WrapErr(err, "Error deploying systemd file(s) Repo: %s, Path: %s", mo.Target.Name, mo.Target.Systemd.TargetPath)
 	}
 	sd := mo.Target.Systemd
 	if !sd.Enable {

--- a/pkg/engine/utils/errors.go
+++ b/pkg/engine/utils/errors.go
@@ -1,0 +1,8 @@
+package utils
+
+import "fmt"
+
+func WrapErr(e error, msg string, args ...interface{}) error {
+	final_msg := fmt.Sprintf(msg, args...)
+	return fmt.Errorf("%s: %s", final_msg, e)
+}

--- a/pkg/engine/utils/errors_test.go
+++ b/pkg/engine/utils/errors_test.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestWrapErr(t *testing.T) {
+	msg := "Error"
+	e := errors.New("other_err")
+	err := WrapErr(e, msg).Error()
+	expected := "Error: other_err"
+	if err != expected {
+		t.Fatalf("Failed: err: %s != %s", err, expected)
+	}
+
+	msg = "Error %s"
+	e = errors.New("other_err")
+	err = WrapErr(e, msg, "test").Error()
+	expected = "Error test: other_err"
+	if err != expected {
+		t.Fatalf("Failed: err: %s != %s", err, expected)
+	}
+}

--- a/pkg/engine/utils/util.go
+++ b/pkg/engine/utils/util.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"context"
+
+	"github.com/containers/podman/v4/pkg/bindings/images"
+	"k8s.io/klog/v2"
+)
+
+func FetchImage(conn context.Context, image string) error {
+	present, err := images.Exists(conn, image, nil)
+	klog.Infof("Is image present? %t", present)
+	if err != nil {
+		return err
+	}
+
+	if !present {
+		_, err = images.Pull(conn, image, nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
@cooktheryan @josephsawaya check this out :1st_place_medal: 
I have picked Joseph's commits from Friday and:
* reset target/method if any error is encountered - with any error _and_ with initial Run, target.method.InitialRun is set to true
    * if error is b4 successfully fetching a commit for the target, harpoon will reset/retry the clone each run until it succeeds
    * if error is after the initial fetch of a commit, harpoon will reset but will not re-clone on subsequent runs
* with each processMethod run, the resetTarget is called first, (with a nil error) to either set the InitialRun to true/return if errors are detected _or_ to obtain latest commit from remote and continue processing
* with any errors that occur during processing, the `resetTarget` function is called to determine what next course of action should be for the next run, either
    * try again to re-clone (if, for example, a branch is configured that does not exist)
    * set InitialRun = true and try again (without re-cloning) (if, for example, any other processing error occurs)