### PR TITLE
Add yaml support for raw method

### DIFF
--- a/examples/raw/color2.yaml
+++ b/examples/raw/color2.yaml
@@ -1,4 +1,4 @@
-Image: "docker.io/mmushad/simple-webapp-color:latest"
+Image: "docker.io/mmumshad/simple-webapp-color:latest"
 Name: "colors2"
 Env:
   APP_COLOR: "pink"

--- a/pkg/engine/harpoon.go
+++ b/pkg/engine/harpoon.go
@@ -237,7 +237,7 @@ func (hc *HarpoonConfig) processRaw(ctx context.Context, target *api.Target, sch
 	defer target.Mu.Unlock()
 
 	initial := target.Raw.InitialRun
-	tag := []string{".json"}
+	tag := []string{".json", ".yaml", ".yml"}
 	var targetFile string
 	mo := &FileMountOptions{
 		Conn:   hc.Conn,
@@ -648,7 +648,7 @@ func (hc *HarpoonConfig) getClone(target *api.Target) error {
 		}
 		_, err = git.PlainClone(absPath, false, &git.CloneOptions{
 			Auth: &http.BasicAuth{
-				Username: user,
+				Username: user, // the value of this field should not matter when using a PAT
 				Password: hc.PAT,
 			},
 			URL:           target.Url,


### PR DESCRIPTION
This commit adds support for using yaml files as a
spec for the raw method.

Depends on #131  

Fixes: #77 

Signed-off-by: Joseph Sawaya <jsawaya@redhat.com>