### PR TITLE
Fix typo in image string in colors2 yaml

### DIFF
--- a/examples/raw/color2.yaml
+++ b/examples/raw/color2.yaml
@@ -1,4 +1,4 @@
-Image: "docker.io/mmushad/simple-webapp-color:latest"
+Image: "docker.io/mmumshad/simple-webapp-color:latest"
 Name: "colors2"
 Env:
   APP_COLOR: "pink"


### PR DESCRIPTION
This commit fixes a typo in the image url string
in examples/raw/colors2.yaml

Signed-off-by: Joseph Sawaya <jsawaya@redhat.com>