### PR TITLE
Separate path and dest from file mount options

### DIFF
--- a/pkg/engine/filetransfer.go
+++ b/pkg/engine/filetransfer.go
@@ -16,10 +16,10 @@ import (
 
 const stopped = define.ContainerStateStopped
 
-func fileTransferPodman(ctx context.Context, mo *FileMountOptions) error {
-	if mo.Previous != nil {
-		pathToRemove := filepath.Join(mo.Dest, filepath.Base(*mo.Previous))
-		s := generateSpecRemove(mo.Method, filepath.Base(pathToRemove), pathToRemove, mo.Dest, mo.Target)
+func fileTransferPodman(ctx context.Context, mo *FileMountOptions, prev *string, dest string) error {
+	if prev != nil {
+		pathToRemove := filepath.Join(dest, filepath.Base(*prev))
+		s := generateSpecRemove(mo.Method, filepath.Base(pathToRemove), pathToRemove, dest, mo.Target)
 		createResponse, err := createAndStartContainer(mo.Conn, s)
 		if err != nil {
 			return err
@@ -40,9 +40,9 @@ func fileTransferPodman(ctx context.Context, mo *FileMountOptions) error {
 	file := filepath.Base(mo.Path)
 
 	source := filepath.Join("/opt", mo.Path)
-	copyFile := (source + " " + mo.Dest)
+	copyFile := (source + " " + dest)
 
-	s := generateSpec(mo.Method, file, copyFile, mo.Dest, mo.Target)
+	s := generateSpec(mo.Method, file, copyFile, dest, mo.Target)
 	createResponse, err := createAndStartContainer(mo.Conn, s)
 	if err != nil {
 		return err

--- a/pkg/engine/kube.go
+++ b/pkg/engine/kube.go
@@ -22,14 +22,14 @@ import (
 	k8syaml "sigs.k8s.io/yaml"
 )
 
-func kubePodman(ctx context.Context, mo *FileMountOptions) error {
+func kubePodman(ctx context.Context, mo *FileMountOptions, prev *string) error {
 
 	if mo.Path != deleteFile {
 		klog.Infof("Creating podman container from %s using kube method", mo.Path)
 	}
 
-	if mo.Previous != nil {
-		err := stopPods(mo.Conn, []byte(*mo.Previous))
+	if prev != nil {
+		err := stopPods(mo.Conn, []byte(*prev))
 		if err != nil {
 			return utils.WrapErr(err, "Error stopping pods")
 		}

--- a/pkg/engine/raw.go
+++ b/pkg/engine/raw.go
@@ -60,11 +60,11 @@ type RawPod struct {
 	Volumes []namedVolume     `json:"Volumes" yaml:"Volumes"`
 }
 
-func rawPodman(ctx context.Context, mo *FileMountOptions) error {
+func rawPodman(ctx context.Context, mo *FileMountOptions, prev *string) error {
 
 	// Delete previous file's podxz
-	if mo.Previous != nil {
-		raw, err := rawPodFromBytes([]byte(*mo.Previous))
+	if prev != nil {
+		raw, err := rawPodFromBytes([]byte(*prev))
 		if err != nil {
 			return err
 		}

--- a/pkg/engine/systemd.go
+++ b/pkg/engine/systemd.go
@@ -13,9 +13,9 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func systemdPodman(ctx context.Context, mo *FileMountOptions) error {
+func systemdPodman(ctx context.Context, mo *FileMountOptions, prev *string, dest string) error {
 	klog.Infof("Deploying systemd file(s) %s", mo.Path)
-	if err := fileTransferPodman(ctx, mo); err != nil {
+	if err := fileTransferPodman(ctx, mo, prev, dest); err != nil {
 		return utils.WrapErr(err, "Error deploying systemd file(s) Repo: %s, Path: %s", mo.Target.Name, mo.Target.Systemd.TargetPath)
 	}
 	sd := mo.Target.Systemd
@@ -23,7 +23,7 @@ func systemdPodman(ctx context.Context, mo *FileMountOptions) error {
 		klog.Infof("Repo: %s, systemd target successfully processed", mo.Target.Name)
 		return nil
 	}
-	return enableSystemdService(mo.Conn, sd.Root, mo.Dest, filepath.Base(mo.Path), mo.Target.Name)
+	return enableSystemdService(mo.Conn, sd.Root, dest, filepath.Base(mo.Path), mo.Target.Name)
 }
 
 func enableSystemdService(conn context.Context, root bool, systemdPath, service, repoName string) error {


### PR DESCRIPTION
This commit separates the path and dest members
of the fileMountOptions struct in order to isolate
those variables for running the engine method
concurrently.

Signed-off-by: Joseph Sawaya <jsawaya@redhat.com>