### PR TITLE
Separate path from mo and run engine method concurrently

### DIFF
--- a/pkg/engine/ansible.go
+++ b/pkg/engine/ansible.go
@@ -11,14 +11,14 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func ansiblePodman(ctx context.Context, mo *FileMountOptions) error {
+func ansiblePodman(ctx context.Context, mo *FileMountOptions, path string) error {
 	// TODO: add logic to remove
-	if mo.Path == deleteFile {
+	if path == deleteFile {
 		return nil
 	}
-	klog.Infof("Deploying Ansible playbook %s\n", mo.Path)
+	klog.Infof("Deploying Ansible playbook %s\n", path)
 
-	copyFile := ("/opt/" + mo.Path)
+	copyFile := ("/opt/" + path)
 	sshImage := "quay.io/harpoon/harpoon-ansible:latest"
 
 	klog.Infof("Identifying if harpoon-ansible image exists locally")

--- a/pkg/engine/filetransfer.go
+++ b/pkg/engine/filetransfer.go
@@ -16,7 +16,7 @@ import (
 
 const stopped = define.ContainerStateStopped
 
-func fileTransferPodman(ctx context.Context, mo *FileMountOptions, prev *string, dest string) error {
+func fileTransferPodman(ctx context.Context, mo *FileMountOptions, path, dest string, prev *string) error {
 	if prev != nil {
 		pathToRemove := filepath.Join(dest, filepath.Base(*prev))
 		s := generateSpecRemove(mo.Method, filepath.Base(pathToRemove), pathToRemove, dest, mo.Target)
@@ -31,15 +31,15 @@ func fileTransferPodman(ctx context.Context, mo *FileMountOptions, prev *string,
 		}
 	}
 
-	if mo.Path == deleteFile {
+	if path == deleteFile {
 		return nil
 	}
 
-	klog.Infof("Deploying file(s) %s", mo.Path)
+	klog.Infof("Deploying file(s) %s", path)
 
-	file := filepath.Base(mo.Path)
+	file := filepath.Base(path)
 
-	source := filepath.Join("/opt", mo.Path)
+	source := filepath.Join("/opt", path)
 	copyFile := (source + " " + dest)
 
 	s := generateSpec(mo.Method, file, copyFile, dest, mo.Target)

--- a/pkg/engine/kube.go
+++ b/pkg/engine/kube.go
@@ -22,10 +22,10 @@ import (
 	k8syaml "sigs.k8s.io/yaml"
 )
 
-func kubePodman(ctx context.Context, mo *FileMountOptions, prev *string) error {
+func kubePodman(ctx context.Context, mo *FileMountOptions, path string, prev *string) error {
 
-	if mo.Path != deleteFile {
-		klog.Infof("Creating podman container from %s using kube method", mo.Path)
+	if path != deleteFile {
+		klog.Infof("Creating podman container from %s using kube method", path)
 	}
 
 	if prev != nil {
@@ -35,8 +35,8 @@ func kubePodman(ctx context.Context, mo *FileMountOptions, prev *string) error {
 		}
 	}
 
-	if mo.Path != deleteFile {
-		kubeYaml, err := ioutil.ReadFile(mo.Path)
+	if path != deleteFile {
+		kubeYaml, err := ioutil.ReadFile(path)
 		if err != nil {
 			return utils.WrapErr(err, "Error reading file")
 		}
@@ -44,12 +44,13 @@ func kubePodman(ctx context.Context, mo *FileMountOptions, prev *string) error {
 		// Try stopping the pods, don't care if they don't exist
 		err = stopPods(mo.Conn, kubeYaml)
 		if err != nil {
+			klog.Infof("ERR: %s\n", kubeYaml)
 			if !strings.Contains(err.Error(), "no such pod") {
 				return utils.WrapErr(err, "Error stopping pods")
 			}
 		}
 
-		err = createPods(mo.Conn, mo.Path, kubeYaml)
+		err = createPods(mo.Conn, path, kubeYaml)
 		if err != nil {
 			return utils.WrapErr(err, "Error creating pod")
 		}
@@ -59,6 +60,7 @@ func kubePodman(ctx context.Context, mo *FileMountOptions, prev *string) error {
 }
 
 func stopPods(ctx context.Context, podSpec []byte) error {
+	klog.Info("IN")
 	conn, err := bindings.GetClient(ctx)
 	if err != nil {
 		return utils.WrapErr(err, "Error getting podman connection")

--- a/pkg/engine/raw.go
+++ b/pkg/engine/raw.go
@@ -60,7 +60,7 @@ type RawPod struct {
 	Volumes []namedVolume     `json:"Volumes" yaml:"Volumes"`
 }
 
-func rawPodman(ctx context.Context, mo *FileMountOptions, prev *string) error {
+func rawPodman(ctx context.Context, mo *FileMountOptions, path string, prev *string) error {
 
 	// Delete previous file's podxz
 	if prev != nil {
@@ -77,13 +77,13 @@ func rawPodman(ctx context.Context, mo *FileMountOptions, prev *string) error {
 		klog.Infof("Deleted podman container %s", raw.Name)
 	}
 
-	if mo.Path == deleteFile {
+	if path == deleteFile {
 		return nil
 	}
 
-	klog.Infof("Creating podman container from %s", mo.Path)
+	klog.Infof("Creating podman container from %s", path)
 
-	rawFile, err := ioutil.ReadFile(mo.Path)
+	rawFile, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err
 	}

--- a/pkg/engine/systemd.go
+++ b/pkg/engine/systemd.go
@@ -13,9 +13,9 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func systemdPodman(ctx context.Context, mo *FileMountOptions, prev *string, dest string) error {
-	klog.Infof("Deploying systemd file(s) %s", mo.Path)
-	if err := fileTransferPodman(ctx, mo, prev, dest); err != nil {
+func systemdPodman(ctx context.Context, mo *FileMountOptions, path, dest string, prev *string) error {
+	klog.Infof("Deploying systemd file(s) %s", path)
+	if err := fileTransferPodman(ctx, mo, path, dest, prev); err != nil {
 		return utils.WrapErr(err, "Error deploying systemd file(s) Repo: %s, Path: %s", mo.Target.Name, mo.Target.Systemd.TargetPath)
 	}
 	sd := mo.Target.Systemd
@@ -23,7 +23,7 @@ func systemdPodman(ctx context.Context, mo *FileMountOptions, prev *string, dest
 		klog.Infof("Repo: %s, systemd target successfully processed", mo.Target.Name)
 		return nil
 	}
-	return enableSystemdService(mo.Conn, sd.Root, dest, filepath.Base(mo.Path), mo.Target.Name)
+	return enableSystemdService(mo.Conn, sd.Root, dest, filepath.Base(path), mo.Target.Name)
 }
 
 func enableSystemdService(conn context.Context, root bool, systemdPath, service, repoName string) error {


### PR DESCRIPTION
This commit separates the path member from the fileMountOptions
struct so it can be used concurrently.

This commit also changes the engineMethod to be run concurrently
for different files specified in the method.

Signed-off-by: Joseph Sawaya <jsawaya@redhat.com>