### PR TITLE
Fix config start

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -58,7 +58,7 @@ jobs:
 
   build-ansible-arm:
     runs-on: ubuntu-latest
-    needs: [ build, raw-validate, harpoon-config-reload-validate, default-volume-validate, kube-validate, systemd-validate, systemd-enable-validate,  systemd-validate-exact-file, multi-engine-validate, make-change-to-repo, filetransfer-validate, filetransfer-validate-exact-file, ansible-validate ]
+    needs: [ build, raw-validate, harpoon-config-target-no-config-validate, harpoon-config-reload-validate, default-volume-validate, kube-validate, systemd-validate, systemd-enable-validate,  systemd-validate-exact-file, multi-engine-validate, make-change-to-repo, filetransfer-validate, filetransfer-validate-exact-file, ansible-validate ]
     if: >
       (github.event_name == 'push' || github.event_name == 'schedule') &&
       (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
@@ -105,7 +105,7 @@ jobs:
 
   build-systemd-arm:
     runs-on: ubuntu-latest
-    needs: [ build, raw-validate, harpoon-config-reload-validate, default-volume-validate, kube-validate, systemd-validate, systemd-enable-validate,  systemd-validate-exact-file, multi-engine-validate, make-change-to-repo, filetransfer-validate, filetransfer-validate-exact-file, ansible-validate ]
+    needs: [ build, raw-validate, harpoon-config-target-no-config-validate, harpoon-config-reload-validate, default-volume-validate, kube-validate, systemd-validate, systemd-enable-validate,  systemd-validate-exact-file, multi-engine-validate, make-change-to-repo, filetransfer-validate, filetransfer-validate-exact-file, ansible-validate ]
     if: >
       (github.event_name == 'push' || github.event_name == 'schedule') &&
       (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
@@ -129,6 +129,45 @@ jobs:
         with:
           name: systemd-image-arm
           path: /tmp/systemd-arm.tar
+
+  harpoon-config-target-no-config-validate:
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Enable the podman socket
+        run: sudo systemctl enable --now podman.socket
+
+      - name: pull artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: harpoon-image
+          path: /tmp
+
+      - name: Load the image
+        run: sudo podman load -i /tmp/harpoon.tar
+
+      - name: tag the image
+        run: sudo podman tag quay.io/harpoon/harpoon-amd:latest quay.io/harpoon/harpoon:latest
+
+      - name: create harpoon config directory
+        run: sudo mkdir /root/.harpoon
+
+      - name: Start harpoon
+        run: sudo podman run -d --name harpoon -v /root/.harpoon:/opt/mount -e HARPOON_CONFIG_URL=https://raw.githubusercontent.com/redhat-et/harpoon/main/examples/raw-config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock quay.io/harpoon/harpoon-amd:latest
+
+      - name: Wait for harpoon to deploy
+        run: sleep 2m
+
+      - name: Logs
+        run: sudo podman logs harpoon
+
+      - name: verify container is running
+        run: if [[ $(sudo podman ps | grep -v CON= | grep colors | wc -l) = "2" ]] ; then echo "Container successfully launched"; else exit 1; fi
+
+      - name: Print the current running container
+        run: sudo podman ps
 
   harpoon-config-reload-validate:
     runs-on: ubuntu-latest
@@ -661,7 +700,7 @@ jobs:
 
   push-amd-image-to-registry:
     runs-on: ubuntu-latest
-    needs: [ build, raw-validate, harpoon-config-reload-validate, default-volume-validate, kube-validate, systemd-validate, systemd-enable-validate, systemd-validate-exact-file, multi-engine-validate, make-change-to-repo, filetransfer-validate, filetransfer-validate-exact-file, ansible-validate ]
+    needs: [ build, raw-validate, harpoon-config-target-no-config-validate, harpoon-config-reload-validate, default-volume-validate, kube-validate, systemd-validate, systemd-enable-validate, systemd-validate-exact-file, multi-engine-validate, make-change-to-repo, filetransfer-validate, filetransfer-validate-exact-file, ansible-validate ]
     if: >
       (github.event_name == 'push' || github.event_name == 'schedule') &&
       (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
@@ -688,7 +727,7 @@ jobs:
 
   build-arm-and-manifest-list:
     runs-on: ubuntu-latest
-    needs: [ build, raw-validate, harpoon-config-reload-validate, default-volume-validate, kube-validate, systemd-validate, systemd-enable-validate, systemd-validate-exact-file, multi-engine-validate, make-change-to-repo, filetransfer-validate, filetransfer-validate-exact-file, ansible-validate ]
+    needs: [ build, raw-validate, harpoon-config-target-no-config-validate, harpoon-config-reload-validate, default-volume-validate, kube-validate, systemd-validate, systemd-enable-validate, systemd-validate-exact-file, multi-engine-validate, make-change-to-repo, filetransfer-validate, filetransfer-validate-exact-file, ansible-validate ]
     if: >
       (github.event_name == 'push' || github.event_name == 'schedule') &&
       (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))

--- a/pkg/engine/start.go
+++ b/pkg/engine/start.go
@@ -24,5 +24,12 @@ func init() {
 	}
 	for _, cmd := range cmdGroup {
 		harpoonConfig.bindFlags(cmd)
+		if cmd.Flags().Changed("config") {
+			configFile, err := cmd.Flags().GetString("config")
+			if err != nil {
+				cobra.CheckErr(err)
+			}
+			harpoonConfig.configFile = configFile
+		}
 	}
 }

--- a/systemd/harpoon-root.service
+++ b/systemd/harpoon-root.service
@@ -11,7 +11,7 @@ Restart=always
 TimeoutStopSec=65
 ExecStartPre=/usr/bin/mkdir -p %h/.harpoon
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
-ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --sdnotify=conmon --replace --label io.containers.autoupdate=registry -d --name harpoon -v harpoon-volume:/opt -v %h/.harpoon:/opt/config -v /run/podman/podman.sock:/run/podman/podman.sock --env-host quay.io/harpoon/harpoon:latest
+ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --sdnotify=conmon --replace --label io.containers.autoupdate=registry -d --name harpoon -v harpoon-volume:/opt -v %h/.harpoon:/opt/mount -v /run/podman/podman.sock:/run/podman/podman.sock --env-host quay.io/harpoon/harpoon:latest
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 Type=notify

--- a/systemd/harpoon-user.service
+++ b/systemd/harpoon-user.service
@@ -11,7 +11,7 @@ Restart=always
 TimeoutStopSec=65
 ExecStartPre=/usr/bin/mkdir -p %h/.harpoon
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
-ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --sdnotify=conmon --replace --label io.containers.autoupdate=registry -d --name harpoon -v harpoon-volume:/opt -v %h/.harpoon:/opt/config -v /run/user/1000/podman/podman.sock:/run/podman/podman.sock --env-host quay.io/harpoon/harpoon:latest
+ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --sdnotify=conmon --replace --label io.containers.autoupdate=registry -d --name harpoon -v harpoon-volume:/opt -v %h/.harpoon:/opt/mount -v /run/user/1000/podman/podman.sock:/run/podman/podman.sock --env-host quay.io/harpoon/harpoon:latest
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 Type=notify


### PR DESCRIPTION
* starting with empty config file had a bug, this PR fixes it and adds a workflow to test
* also updates the example unit files to mount the config directory with `/opt/mount` since this allows harpoon to start without a config file and only with the $HARPOON_CONFIG_URL
@cooktheryan @josephsawaya 