### PR TITLE
add systemd restart

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -58,7 +58,7 @@ jobs:
 
   build-ansible-arm:
     runs-on: ubuntu-latest
-    needs: [ build, raw-validate, harpoon-config-target-no-config-validate, harpoon-config-reload-validate, default-volume-validate, kube-validate, systemd-validate, systemd-enable-validate,  systemd-validate-exact-file, multi-engine-validate, make-change-to-repo, filetransfer-validate, filetransfer-validate-exact-file, ansible-validate ]
+    needs: [ build, raw-validate, harpoon-config-target-no-config-validate, harpoon-config-reload-validate, default-volume-validate, kube-validate, systemd-validate, systemd-enable-validate, systemd-restart-validate, systemd-validate-exact-file, multi-engine-validate, make-change-to-repo, filetransfer-validate, filetransfer-validate-exact-file, ansible-validate ]
     if: >
       (github.event_name == 'push' || github.event_name == 'schedule') &&
       (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
@@ -105,7 +105,7 @@ jobs:
 
   build-systemd-arm:
     runs-on: ubuntu-latest
-    needs: [ build, raw-validate, harpoon-config-target-no-config-validate, harpoon-config-reload-validate, default-volume-validate, kube-validate, systemd-validate, systemd-enable-validate,  systemd-validate-exact-file, multi-engine-validate, make-change-to-repo, filetransfer-validate, filetransfer-validate-exact-file, ansible-validate ]
+    needs: [ build, raw-validate, harpoon-config-target-no-config-validate, harpoon-config-reload-validate, default-volume-validate, kube-validate, systemd-validate, systemd-enable-validate, systemd-restart-validate, systemd-validate-exact-file, multi-engine-validate, make-change-to-repo, filetransfer-validate, filetransfer-validate-exact-file, ansible-validate ]
     if: >
       (github.event_name == 'push' || github.event_name == 'schedule') &&
       (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
@@ -448,6 +448,57 @@ jobs:
       - name: ensure httpd.service is running
         run:  sudo systemctl is-active --quiet httpd.service
 
+  systemd-restart-validate:
+    runs-on: ubuntu-latest
+    needs: [ build , build-systemd-amd ]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Enable the podman socket
+        run: sudo systemctl enable --now podman.socket
+
+      - name: pull artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: harpoon-image
+          path: /tmp
+
+      - name: Load the image
+        run: sudo podman load -i /tmp/harpoon.tar
+
+      - name: tag the image
+        run: sudo podman tag quay.io/harpoon/harpoon-amd:latest quay.io/harpoon/harpoon:latest
+
+      - name: pull systemd amd artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: systemd-image-amd
+          path: /tmp
+
+      - name: Load the systemd image
+        run: sudo podman load -i /tmp/systemd-amd.tar
+
+      - name: tag the image
+        run: sudo podman tag quay.io/harpoon/harpoon-systemd-amd:latest quay.io/harpoon/harpoon-systemd:latest
+
+      - name: Start harpoon
+        run: sudo podman run -d --name harpoon -v harpoon-volume:/opt -v ./examples/systemd-restart.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock quay.io/harpoon/harpoon-amd:latest
+
+      - name: Wait for harpoon to deploy
+        run: sleep 4m
+
+      - name: Logs
+        run: sudo podman logs harpoon
+
+      - name: list files
+        run: sudo ls /etc/systemd/system/httpd.service
+
+      - name: ensure systemd containers are gone
+        run: sudo podman ps -a
+
+      - name: ensure httpd.service is running
+        run:  sudo systemctl is-active --quiet httpd.service
+
   ansible-validate:
     runs-on: ubuntu-latest
     needs: [ build, build-ansible-amd ]
@@ -700,7 +751,7 @@ jobs:
 
   push-amd-image-to-registry:
     runs-on: ubuntu-latest
-    needs: [ build, raw-validate, harpoon-config-target-no-config-validate, harpoon-config-reload-validate, default-volume-validate, kube-validate, systemd-validate, systemd-enable-validate, systemd-validate-exact-file, multi-engine-validate, make-change-to-repo, filetransfer-validate, filetransfer-validate-exact-file, ansible-validate ]
+    needs: [ build, raw-validate, harpoon-config-target-no-config-validate, harpoon-config-reload-validate, default-volume-validate, kube-validate, systemd-validate, systemd-enable-validate, systemd-restart-validate, systemd-validate-exact-file, multi-engine-validate, make-change-to-repo, filetransfer-validate, filetransfer-validate-exact-file, ansible-validate ]
     if: >
       (github.event_name == 'push' || github.event_name == 'schedule') &&
       (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
@@ -727,7 +778,7 @@ jobs:
 
   build-arm-and-manifest-list:
     runs-on: ubuntu-latest
-    needs: [ build, raw-validate, harpoon-config-target-no-config-validate, harpoon-config-reload-validate, default-volume-validate, kube-validate, systemd-validate, systemd-enable-validate, systemd-validate-exact-file, multi-engine-validate, make-change-to-repo, filetransfer-validate, filetransfer-validate-exact-file, ansible-validate ]
+    needs: [ build, raw-validate, harpoon-config-target-no-config-validate, harpoon-config-reload-validate, default-volume-validate, kube-validate, systemd-validate, systemd-enable-validate, systemd-restart-validate, systemd-validate-exact-file, multi-engine-validate, make-change-to-repo, filetransfer-validate, filetransfer-validate-exact-file, ansible-validate ]
     if: >
       (github.event_name == 'push' || github.event_name == 'schedule') &&
       (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))

--- a/examples/systemd-restart.yaml
+++ b/examples/systemd-restart.yaml
@@ -1,0 +1,12 @@
+volume: harpoon-volume # this needs to match the volume name passed to the podman run command
+targets:
+- name: harpoon
+  url: http://github.com/redhat-et/harpoon
+  methods:
+    systemd:
+      targetPath: examples/systemd/httpd.service
+      root: true
+      enable: true
+      restart: true
+      schedule: "*/1 * * * *"
+  branch: main

--- a/method_containers/systemd/systemd-script
+++ b/method_containers/systemd/systemd-script
@@ -2,14 +2,18 @@
 
 if [ "$ACTION" == "enable" ]; then
   if [ "$ROOT" == "true" ]; then
+    systemctl daemon-reload
+    sleep 2
     systemctl enable "${SERVICE}" --now
-    sleep 5
+    sleep 2
     if ! systemctl is-active --quiet "${SERVICE}"; then
       exit 1
     fi
   else
+    systemctl --user daemon-reload
+    sleep 2
     systemctl --user enable "${SERVICE}" --now
-    sleep 5
+    sleep 2
     if ! systemctl --user is-active --quiet "${SERVICE}"; then
       exit 1
     fi
@@ -19,15 +23,21 @@ fi
 if [ "$ACTION" == "restart" ]; then
   if [ "$ROOT" == "true" ]; then
     systemctl daemon-reload
-    systemctl restart "${SERVICE}"
-    sleep 5
+    sleep 2
+    systemctl stop "${SERVICE}"
+    sleep 2
+    systemctl start "${SERVICE}"
+    sleep 2
     if ! systemctl is-active --quiet "${SERVICE}"; then
       exit 1
     fi
   else
     systemctl --user daemon-reload
-    systemctl --user restart  "${SERVICE}"
-    sleep 5
+    sleep 2
+    systemctl --user stop "${SERVICE}"
+    sleep 2
+    systemctl --user start "${SERVICE}"
+    sleep 2
     if ! systemctl is-active --quiet "${SERVICE}"; then
       exit 1
     fi

--- a/pkg/engine/types.go
+++ b/pkg/engine/types.go
@@ -70,11 +70,12 @@ type SystemdTarget struct {
 	// If false (default) will place unit file in ~/.config/systemd/user/
 	Root bool `mapstructure:"root"`
 	// If true, will enable and start the systemd service
+	// If true, will reload and restart the service with every scheduled run
+	// Implies Enable=true, will override Enable=false
+	Restart bool `mapstructure:"restart"`
+	// If true, will enable and start the systemd service
 	// If false (default), will place unit file in appropriate systemd path
 	Enable bool `mapstructure:"enable"`
-	// If true, service will be restarted with each run
-	// This is convenient to catch image updates with podman autoupdate=true
-	RestartAlways bool `mapstructure:restartAlways"`
 	// Schedule is how often to check for git updates to the unit file
 	// If Enable is true, service is restarted on schedule regardless of whether there is git diff
 	// This is to, for example, launch with updated image using podman autoupdate, if service runs a podman command


### PR DESCRIPTION
@cooktheryan 
Adding systemd restart services
Expected workflow is to enable the service, then periodically restart the service to pick up any podman `autoupdate=registry` configured unit files. Adds the `SystemdTarget.Restart` boolean